### PR TITLE
register index cards on serving nova

### DIFF
--- a/src/AnalyticsToolServiceProvider.php
+++ b/src/AnalyticsToolServiceProvider.php
@@ -17,14 +17,14 @@ class AnalyticsToolServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'Analytics');
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'Analytics');
 
         $this->app->booted(function () {
             $this->routes();
         });
 
         Nova::serving(function (ServingNova $event) {
-            //
+            Nova::cards(AnalyticsDashboard::$indexCards);
         });
     }
 
@@ -41,7 +41,7 @@ class AnalyticsToolServiceProvider extends ServiceProvider
 
         Route::middleware(['nova', Authorize::class])
                 ->prefix('nova-vendor/bjorndcode/nova-analytics')
-                ->group(__DIR__.'/../routes/api.php');
+                ->group(__DIR__ . '/../routes/api.php');
     }
 
     /**


### PR DESCRIPTION
If cards are only shown in the AnalyticsDashboard-Page and not within the normal Dashboard they are not added to the `Nova::$cards` array and therefore not loaded, which results in cards loading endlessly because of a 404 error they receive when trying to get data from their endpoint.

Calling `Nova::cards(AnalyticsDashboard::$indexCards)` registers all cards. Currently I have to call this myself in my own `NovaServiceProvider`, but since I ran into this issue it might be best to add it to the repositories' code so no one ever has to encounter this again :). 